### PR TITLE
Create with ignore changes desired count and task definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,9 @@ locals {
       type  = "s3"
     }
   ]
+
+  service_arn  = var.create_with_ignore_changes_desired_count_and_task_definition ? join("", aws_ecs_service.service_with_ignore_changes_desired_count_and_task_definition.*.id) : join("", aws_ecs_service.service.*.id)
+  service_name = var.create_with_ignore_changes_desired_count_and_task_definition ? join("", aws_ecs_service.service_with_ignore_changes_desired_count_and_task_definition.*.name) : join("", aws_ecs_service.service.*.name)
 }
 
 resource "aws_ecs_task_definition" "task" {
@@ -325,7 +328,8 @@ EOF
 }
 
 resource "aws_ecs_service" "service" {
-  name = var.name_prefix
+  count = var.create_with_ignore_changes_desired_count_and_task_definition ? 0 : 1
+  name  = var.name_prefix
 
   cluster         = var.cluster_id
   task_definition = "${aws_ecs_task_definition.task.family}:${max(aws_ecs_task_definition.task.revision, data.aws_ecs_task_definition.task.revision)}"
@@ -386,4 +390,76 @@ resource "aws_ecs_service" "service" {
       Name = "${var.name_prefix}-service"
     },
   )
+}
+
+resource "aws_ecs_service" "service_with_ignore_changes_desired_count_and_task_definition" {
+  count = var.create_with_ignore_changes_desired_count_and_task_definition ? 1 : 0
+  name  = var.name_prefix
+
+  cluster         = var.cluster_id
+  task_definition = "${aws_ecs_task_definition.task.family}:${max(aws_ecs_task_definition.task.revision, data.aws_ecs_task_definition.task.revision)}"
+
+  desired_count  = var.desired_count
+  propagate_tags = var.propogate_tags
+
+  platform_version = var.platform_version
+  launch_type      = length(var.capacity_provider_strategy) == 0 ? "FARGATE" : null
+
+  force_new_deployment   = var.force_new_deployment
+  wait_for_steady_state  = var.wait_for_steady_state
+  enable_execute_command = var.enable_execute_command
+
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  health_check_grace_period_seconds  = var.load_balanced ? var.health_check_grace_period_seconds : null
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_service.id]
+    assign_public_ip = var.task_container_assign_public_ip
+  }
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity_provider_strategy
+    content {
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+      base              = lookup(capacity_provider_strategy.value, "base", null)
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.load_balanced ? var.target_groups : []
+    content {
+      container_name   = var.container_name != "" ? var.container_name : var.name_prefix
+      container_port   = lookup(load_balancer.value, "container_port", var.task_container_port)
+      target_group_arn = aws_lb_target_group.task[lookup(load_balancer.value, "target_group_name")].arn
+    }
+  }
+
+  deployment_controller {
+    type = var.deployment_controller_type # CODE_DEPLOY or ECS or EXTERNAL
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registry_arn == "" ? [] : [1]
+    content {
+      registry_arn   = var.service_registry_arn
+      container_name = var.container_name != "" ? var.container_name : var.name_prefix
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-service"
+    },
+  )
+
+  lifecycle {
+    ignore_changes = [
+      task_definition,
+      desired_count
+    ]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "service_arn" {
   description = "The Amazon Resource Name (ARN) that identifies the ECS service."
-  value       = aws_ecs_service.service.id
+  value       = local.service_arn
 }
 
 output "target_group_arn" {
@@ -30,7 +30,7 @@ output "service_sg_id" {
 
 output "service_name" {
   description = "The name of the service."
-  value       = aws_ecs_service.service.name
+  value       = local.service_name
 }
 
 output "log_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -312,3 +312,9 @@ variable "cpu_architecture" {
   default     = "X86_64"
   type        = string
 }
+
+variable "create_with_ignore_changes_desired_count_and_task_definition" {
+  description = "Boolean to ignore changes for attribute desired count and task definition"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Sometimes we want to ignore changes in desired count and task definition since:
1. Task definition is generated by CodeDeploy
2. The Desired count is generated/updated by auto-scaling policy